### PR TITLE
[FEAT/#25] Explicit Backing Fields 관련 코틀린 옵션 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,6 +56,12 @@ android {
     }
 }
 
+kotlin {
+    sourceSets.all {
+        languageSettings.enableLanguageFeature("ExplicitBackingFields")
+    }
+}
+
 dependencies {
 
     implementation(libs.androidx.core.ktx)


### PR DESCRIPTION
## Related issue 🛠
- closed #25

## Work Description ✏️
- Explicit Backing Fields 사용을 위해 gradle에 코틀린 옵션을 추가했습니다.

## Screenshot 📸
없습니다!

## Uncompleted Tasks 😅
> 아직 구현이 안됐거나 미흡한 부분이 있다면 작성해주세요.
- 없습니다!

## To Reviewers (Optional) 📢
> 리뷰어가 특별히 봐줬으면 하는 부분이 있다면 작성해주세요.

혹시 위치가 잘못되었다면 말씀해주세요..!