### PR TITLE
[FIX/#50] 홈화면 QA 해결

### DIFF
--- a/app/src/main/java/com/sopt/shinmungo/presentation/allcategory/navigation/AllCategoryNavigation.kt
+++ b/app/src/main/java/com/sopt/shinmungo/presentation/allcategory/navigation/AllCategoryNavigation.kt
@@ -1,5 +1,7 @@
 package com.sopt.shinmungo.presentation.allcategory.navigation
 
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
@@ -19,7 +21,20 @@ fun NavGraphBuilder.allCategoryScreen(
     navController: NavHostController,
     modifier: Modifier = Modifier
 ) {
-    composable<AllCategory> {
+    composable<AllCategory>(
+        exitTransition = {
+            ExitTransition.None
+        },
+        popEnterTransition = {
+            EnterTransition.None
+        },
+        enterTransition = {
+            EnterTransition.None
+        },
+        popExitTransition = {
+            ExitTransition.None
+        }
+    ) {
         AllCategoryScreen(
             onNavigateBack = navController::navigateUp,
             modifier = modifier

--- a/app/src/main/java/com/sopt/shinmungo/presentation/home/component/button/BannerIconButton.kt
+++ b/app/src/main/java/com/sopt/shinmungo/presentation/home/component/button/BannerIconButton.kt
@@ -37,8 +37,10 @@ private const val EMPTY_DESCRIPTION = ""
 @Preview(showBackground = true)
 @Composable
 private fun BannerIconButtonPreview() {
-    BannerIconButton(
-        imageVector = ImageVector.vectorResource(R.drawable.ic_arrow_right_24),
-        onClick = {}
-    )
+    ShinMunGoTheme {
+        BannerIconButton(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_arrow_right_24),
+            onClick = {}
+        )
+    }
 }

--- a/app/src/main/java/com/sopt/shinmungo/presentation/home/navigation/HomeNavigation.kt
+++ b/app/src/main/java/com/sopt/shinmungo/presentation/home/navigation/HomeNavigation.kt
@@ -1,5 +1,7 @@
 package com.sopt.shinmungo.presentation.home.navigation
 
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
@@ -11,13 +13,28 @@ import com.sopt.shinmungo.presentation.home.HomeRoute
 import com.sopt.shinmungo.presentation.report.navigation.navigateToReport
 import kotlinx.serialization.Serializable
 
-fun NavHostController.navigateToHome(navOptions: NavOptions? = null) = navigate(Home)
+fun NavHostController.navigateToHome(navOptions: NavOptions? = null) =
+    navigate(route = Home, navOptions = navOptions)
 
 fun NavGraphBuilder.homeScreen(
     navController: NavHostController,
     modifier: Modifier = Modifier
 ) {
-    composable<Home> {
+    composable<Home>(
+        exitTransition = {
+            ExitTransition.None
+        },
+        popEnterTransition = {
+            EnterTransition.None
+        },
+        enterTransition = {
+            EnterTransition.None
+        },
+        popExitTransition = {
+            ExitTransition.None
+        }
+    ) {
+
         HomeRoute(
             modifier = modifier,
             navigateToCategory = navController::navigateToAllCategory,
@@ -27,4 +44,4 @@ fun NavGraphBuilder.homeScreen(
 }
 
 @Serializable
-data object Home: MainTabRoute
+data object Home : MainTabRoute

--- a/app/src/main/java/com/sopt/shinmungo/presentation/main/MainNavigator.kt
+++ b/app/src/main/java/com/sopt/shinmungo/presentation/main/MainNavigator.kt
@@ -35,9 +35,11 @@ class MainNavigator(
 
     fun navigate(tab: MainTab) {
         val mainNavOption = navOptions {
-            popUpTo(navController.graph.startDestinationId) {
-                saveState = true
-                inclusive = true
+            navController.currentDestination?.route?.let {
+                popUpTo(it) {
+                    saveState = true
+                    inclusive = true
+                }
             }
             launchSingleTop = true
             restoreState = true

--- a/app/src/main/java/com/sopt/shinmungo/presentation/main/component/MainBottomBars.kt
+++ b/app/src/main/java/com/sopt/shinmungo/presentation/main/component/MainBottomBars.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.sopt.shinmungo.core.designsystem.theme.ShinMunGoTheme
 import com.sopt.shinmungo.core.extension.noRippleClickable
-import com.sopt.shinmungo.core.extension.showIf
 import com.sopt.shinmungo.presentation.main.MainTab
 
 /**

--- a/app/src/main/java/com/sopt/shinmungo/presentation/main/component/MainBottomBars.kt
+++ b/app/src/main/java/com/sopt/shinmungo/presentation/main/component/MainBottomBars.kt
@@ -1,5 +1,10 @@
 package com.sopt.shinmungo.presentation.main.component
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideIn
+import androidx.compose.animation.slideOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -24,6 +29,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.sopt.shinmungo.core.designsystem.theme.ShinMunGoTheme
 import com.sopt.shinmungo.core.extension.noRippleClickable
@@ -54,38 +60,44 @@ fun MainBottomBars(
     selectedColor: Color = ShinMunGoTheme.color.primary,
     unselectedColor: Color = ShinMunGoTheme.color.gray6,
 ) {
-    Card(
-        elevation = CardDefaults.elevatedCardElevation(defaultElevation = 10.dp),
-        shape = RectangleShape,
-        modifier = Modifier.showIf(visibility)
+    AnimatedVisibility(
+        visible = visibility,
+        enter = fadeIn() + slideIn { IntOffset(0, 0) },
+        exit = fadeOut() + slideOut { IntOffset(0, 0) }
     ) {
-        Row(
+        Card(
+            elevation = CardDefaults.elevatedCardElevation(defaultElevation = 10.dp),
+            shape = RectangleShape,
             modifier = modifier
-                .fillMaxWidth()
-                .background(color = containerColor)
-                .navigationBarsPadding()
-                .padding(start = 37.dp, end = 37.dp, top = 8.dp, bottom = 31.dp),
-            horizontalArrangement = Arrangement.SpaceBetween
         ) {
-            tabs.forEach { tab ->
-                val selected = tab == selectedTab
-                val color = if (selected) selectedColor else unselectedColor
-                val icon = if (selected) tab.selectedIconRes else tab.unselectedIconRes
-                Column(
-                    modifier = Modifier.noRippleClickable { onTabSelect(tab) },
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Icon(
-                        imageVector = ImageVector.vectorResource(id = icon),
-                        contentDescription = stringResource(id = tab.title),
-                        tint = color
-                    )
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Text(
-                        text = stringResource(id = tab.title),
-                        style = ShinMunGoTheme.typography.caption6,
-                        color = color
-                    )
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(color = containerColor)
+                    .navigationBarsPadding()
+                    .padding(start = 37.dp, end = 37.dp, top = 8.dp, bottom = 31.dp),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                tabs.forEach { tab ->
+                    val selected = tab == selectedTab
+                    val color = if (selected) selectedColor else unselectedColor
+                    val icon = if (selected) tab.selectedIconRes else tab.unselectedIconRes
+                    Column(
+                        modifier = Modifier.noRippleClickable { onTabSelect(tab) },
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Icon(
+                            imageVector = ImageVector.vectorResource(id = icon),
+                            contentDescription = stringResource(id = tab.title),
+                            tint = color
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = stringResource(id = tab.title),
+                            style = ShinMunGoTheme.typography.caption6,
+                            color = color
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/res/drawable/ic_home_24.xml
+++ b/app/src/main/res/drawable/ic_home_24.xml
@@ -1,7 +1,7 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="25dp"
+    android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="25"
+    android:viewportWidth="24"
     android:viewportHeight="24">
   <path
       android:pathData="M3,10.938C3,9.714 3.561,8.557 4.521,7.799L10.021,3.457C11.475,2.309 13.525,2.309 14.979,3.457L20.479,7.799C21.439,8.557 22,9.714 22,10.938V17.5C22,19.709 20.209,21.5 18,21.5H16.5C15.948,21.5 15.5,21.052 15.5,20.5V17.5C15.5,16.395 14.605,15.5 13.5,15.5H11.5C10.395,15.5 9.5,16.395 9.5,17.5V20.5C9.5,21.052 9.052,21.5 8.5,21.5H7C4.791,21.5 3,19.709 3,17.5L3,10.938Z"


### PR DESCRIPTION
## Related issue 🛠
- closed #50 

## Work Description ✏️
- 바텀바 깜빡거림 이슈 해결
- 바텀바 아이콘 좌우로 움직이는 이슈 해결
- 안전신고 아이콘을 연타할 경우 카테고리 페이지가 계속 호출되는 문제 해결
- 메인화면에서 바텀바로 화면 전환하는 경우 화면이 전환되는 모션 수정

## Screenshot 📸

https://github.com/user-attachments/assets/edcd461c-5509-4f7f-9986-d2de31b68078

## Uncompleted Tasks 😅
> 아직 구현이 안됐거나 미흡한 부분이 있다면 작성해주세요.
- 없어요~!

## To Reviewers (Optional) 📢
> 리뷰어가 특별히 봐줬으면 하는 부분이 있다면 작성해주세요.
- 바텀바 깜빡거리는건 `AnimatedVisibility`로 해결 - 37ed1ee59f8334a750288de9feb655f38d342c8a
- 바텀바 아이콘 움직이는건 아이콘 리소스 파일에서 dp값 고쳐서 해결 - 64d5f9455a632ed5c7527996c018a89804e7cf51
- 안전신고 아이콘 연타는 navOption에 현재 최상위 루트에 대한 `launchSingleTop`을 true로 설정하여 해결 - be5a817482f94dd7520da06aba7c635ee05e39e2
- 화면 전환 모션은 모든 NavGraphBuilder의 확장함수에 transition을 설정하여 해결 - 7d0f14da41b076b1d9a8556a0bab767859abffe6

이상입니다~ 난 끝! 
